### PR TITLE
Adds Mock Service Worker to React-Typescript

### DIFF
--- a/React-TypeScript/login-form/package.json
+++ b/React-TypeScript/login-form/package.json
@@ -12,9 +12,10 @@
     "@types/react-dom": "^16.9.10",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-scripts": "4.0.1",
-    "typescript": "^4.1.2",
-    "web-vitals": "^0.2.4"
+    "react-scripts": "5.0.1",
+    "typescript": "^4.9.5",
+    "web-vitals": "^0.2.4",
+    "msw": "^1.2.2"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
When you try and mock a backend now, you run into dependency issues.
This should solve this problem in the future